### PR TITLE
add codeship and extra options for badges

### DIFF
--- a/.README.md
+++ b/.README.md
@@ -45,6 +45,7 @@ It uses the [Javascript ES6  syntax](https://developer.mozilla.org/en-US/docs/We
  - `badge('github-stars')` : show # of github stars
  - `badge('github-forks')` : show # of github forks
  - `badge('circleci')` : show circleci status
+ - `badge('codeship', 'ProjectUUID')` : show codeship build status
  - all status from [stability-badges](https://github.com/badges/stability-badges)
 
 ### Others

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ It uses the [Javascript ES6  syntax](https://developer.mozilla.org/en-US/docs/We
  - `badge('github-stars')` : show # of github stars
  - `badge('github-forks')` : show # of github forks
  - `badge('circleci')` : show circleci status
+ - `badge('codeship', 'ProjectUUID')` : show codeship build status
  - all status from [stability-badges](https://github.com/badges/stability-badges)
 
 ### Others

--- a/dist/index.js
+++ b/dist/index.js
@@ -22,7 +22,7 @@ var _es6TemplateStrings = require('es6-template-strings');
 
 var _es6TemplateStrings2 = _interopRequireDefault(_es6TemplateStrings);
 
-var _macros = require('./macros');
+var _macros = require("./macros");
 
 var macros = _interopRequireWildcard(_macros);
 
@@ -34,7 +34,11 @@ function toMarkdown(templateContents, data) {
     // bould all functions in ./macros and pass the current scope (data + macros)
     var boundMacros = {};
     Object.keys(macros).forEach(function (key, idx) {
-        boundMacros[key] = function (options) {
+        boundMacros[key] = function () {
+            for (var _len = arguments.length, options = Array(_len), _key = 0; _key < _len; _key++) {
+                options[_key] = arguments[_key];
+            }
+
             return (macros[key] || function () {
                 return '';
             })(options, scope);
@@ -76,7 +80,7 @@ function compile(userPath, fallbackPath, cb) {
  * or the default node-readme `src/.README.md` template
  */
 function createReadme() {
-    var overwrite = arguments[0] === undefined ? true : arguments[0];
+    var overwrite = arguments.length <= 0 || arguments[0] === undefined ? true : arguments[0];
 
     compile('.README.md', _path2['default'].join(__dirname, './.README.md'), function (markdown) {
         var destination = _path2['default'].join(process.cwd(), './README.md');

--- a/dist/macros/badge.js
+++ b/dist/macros/badge.js
@@ -6,7 +6,7 @@ Object.defineProperty(exports, '__esModule', {
 exports['default'] = badge;
 
 function image(src) {
-    var title = arguments[1] === undefined ? '' : arguments[1];
+    var title = arguments.length <= 1 || arguments[1] === undefined ? '' : arguments[1];
 
     return '![' + title + '](' + src + ')';
 }
@@ -35,6 +35,10 @@ var badges = {
     },
     'travis-status': function travisStatus(scope) {
         return image('https://img.shields.io/travis/' + getRepoPath(scope.pkg.repository) + '.svg', 'travis-status');
+    },
+    'codeship': function codeship(scope, options) {
+        var projectId = options.splice(0, 1)[0];
+        return image('https://img.shields.io/codeship/' + projectId + '.svg', 'codeship-status');
     },
     'github-issues': function githubIssues(scope) {
         return image('https://img.shields.io/github/issues/' + getRepoPath(scope.pkg.repository) + '.svg', 'github-issues');
@@ -81,8 +85,9 @@ var badges = {
     }
 };
 
-function badge(type, scope) {
-    return badges[type] ? badges[type](scope) : '';
+function badge(options, scope) {
+    var type = options.splice(0, 1)[0];
+    return badges[type] ? badges[type](scope, options) : '';
 }
 
 module.exports = exports['default'];

--- a/dist/macros/dependencies.js
+++ b/dist/macros/dependencies.js
@@ -8,14 +8,14 @@ exports['default'] = dependencies;
 function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) arr2[i] = arr[i]; return arr2; } else { return Array.from(arr); } }
 
 function singleDep(name, version) {
-    var dev = arguments[2] === undefined ? false : arguments[2];
+    var dev = arguments.length <= 2 || arguments[2] === undefined ? false : arguments[2];
 
     var check = dev ? '✔' : '✖';
     return '[' + name + '](https://www.npmjs.com/package/' + name + ') | ' + version + ' | ' + check;
 }
 
 function dependenciesList(obj) {
-    var dev = arguments[1] === undefined ? false : arguments[1];
+    var dev = arguments.length <= 1 || arguments[1] === undefined ? false : arguments[1];
 
     if (!obj) {
         obj = {};

--- a/dist/macros/license.js
+++ b/dist/macros/license.js
@@ -17,7 +17,7 @@ function license(options, scope) {
     } else if (scope.pkg.licenses) {
         return scope.pkg.licenses.map(function (license) {
             return singleLicense(license.type);
-        }).join(';');
+        }).join('\;');
     }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,9 @@ function toMarkdown(templateContents, data) {
     // bould all functions in ./macros and pass the current scope (data + macros)
     let boundMacros = {};
     Object.keys(macros).forEach((key, idx) => {
-      boundMacros[key] = options => (macros[key] || function(){ return '';})(options, scope);
+      boundMacros[key] = function(...options) {
+        return (macros[key] || function(){ return '';})(options, scope);
+      }
     });
     let scope = { ...data, ...boundMacros};
     let markdown = template(templateContents, scope);

--- a/src/macros/badge.js
+++ b/src/macros/badge.js
@@ -28,6 +28,10 @@ const badges = {
     'travis-status': scope => {
         return image(`https://img.shields.io/travis/${getRepoPath(scope.pkg.repository)}.svg`, 'travis-status');
     },
+    'codeship': (scope, options) => {
+        let projectId = options.splice(0, 1)[0];
+        return image(`https://img.shields.io/codeship/${projectId}.svg`, 'codeship-status');
+    },
     'github-issues': scope => {
         return image(`https://img.shields.io/github/issues/${getRepoPath(scope.pkg.repository)}.svg`, 'github-issues');
     },
@@ -73,6 +77,7 @@ const badges = {
     }
 };
 
-export default function badge(type, scope) {
-    return badges[type]?badges[type](scope):'';
+export default function badge(options, scope) {
+    let type = options.splice(0, 1)[0];
+    return badges[type]?badges[type](scope, options):'';
 }


### PR DESCRIPTION
The codeship badge requires a token so I made these changes to allow a token or extra options to be passed to a badge.

A lot of other badges on [http://shields.io/](http://shields.io/) require similar extra options, which could be easily added with the changes in this PR.
